### PR TITLE
chore(core): allow custom regex for natural users

### DIFF
--- a/lib/monsoon_openstack_auth/version.rb
+++ b/lib/monsoon_openstack_auth/version.rb
@@ -1,3 +1,3 @@
 module MonsoonOpenstackAuth
-  VERSION = '2.0.11'.freeze
+  VERSION = '2.0.12'.freeze
 end


### PR DESCRIPTION
# Summary

This PR introduces a custom regex pattern for natural user authentication. Previously, only a default pattern was used, but now the host app can configure a custom regex to define natural users more flexibly.

# Changes Made

- Added support for a configurable regex pattern for natural users.
- Handled potential `RegexpError` exceptions to ensure robustness.
- Preserved the default regex pattern as a fallback.

# Why?

This change allows for more flexibility in defining natural user accounts while ensuring backward compatibility with existing patterns.

